### PR TITLE
Update Vite documentation (2.8.3)

### DIFF
--- a/lib/docs/filters/vite/clean_html.rb
+++ b/lib/docs/filters/vite/clean_html.rb
@@ -1,0 +1,50 @@
+module Docs
+  class Vite
+    class CleanHtmlFilter < Filter
+      def call
+        return '<h1>Vite</h1>' if root_page?
+        @doc = at_css('main .content > div')
+
+        css('.demo', '.guide-links', '.footer', '#ad').remove
+        css('.header-anchor', '.page-edit', '.page-nav').remove
+
+        css('.custom-block-title').each do |node|
+          node.name = 'strong'
+        end
+
+        # Remove CodePen div
+        css('.codepen').each do |node|
+          next if node.previous_element.nil?
+          span = node.css('span:contains("See the Pen")').remove
+          node.previous_element.add_child(' ')
+          node.previous_element.add_child(span)
+          node.remove
+        end
+
+        # Remove code highlighting
+        css('figure').each do |node|
+          node.name = 'pre'
+          node.content = node.at_css('td.code pre').css('.line').map(&:content).join("\n")
+          node['data-language'] = node['class'][/highlight (\w+)/, 1]
+        end
+
+        css('.line-numbers-wrapper').remove
+        css('pre').each do |node|
+          node.content = node.content.strip
+          node['data-language'] = 'javascript'
+        end
+
+        css('iframe').each do |node|
+          node['sandbox'] = 'allow-forms allow-scripts allow-same-origin'
+          node.remove if node['src'][/player.vimeo.com/] # https://v3.vuejs.org/guide/migration/introduction.html#overview
+        end
+
+        css('details').each do |node|
+          node.name = 'div'
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/vite/entries.rb
+++ b/lib/docs/filters/vite/entries.rb
@@ -1,0 +1,23 @@
+module Docs
+  class Vite
+    class EntriesFilter < Docs::EntriesFilter
+      def get_name
+        name = at_css('h1').content
+        name.sub! %r{\s*#\s*}, ''
+        name
+      end
+
+      def get_type
+        at_css('header nav .item.active').content.strip
+      end
+
+      def additional_entries
+        css('h2, h3').each_with_object [] do |node, entries|
+          type = node.content.strip
+          type.sub! %r{\s*#\s*}, ''
+          entries << ["#{name}: #{type}", node['id']]
+        end
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/vite.rb
+++ b/lib/docs/scrapers/vite.rb
@@ -8,7 +8,6 @@ module Docs
       code: 'https://github.com/vitejs/vite'
     }
 
-    options[:container] = 'main'
     options[:root_title] = 'Vite'
 
     options[:attribution] = <<-HTML
@@ -16,10 +15,10 @@ module Docs
       Licensed under the MIT License.
     HTML
 
-    self.release = '2.7.5'
+    self.release = '2.8.3'
     self.base_url = 'https://vitejs.dev/'
     self.initial_paths = %w(guide/)
-    html_filters.push 'vue/entries_v3', 'vue/clean_html'
+    html_filters.push 'vite/entries', 'vite/clean_html'
 
     def get_latest_version(opts)
       get_npm_version('vite', opts)


### PR DESCRIPTION
<!-- Remove the sections that don't apply to your PR. -->

<!-- Replace the `[ ]` with a `[x]` in checklists once you’ve completed each step. -->
<!-- Please create a draft PR when you haven't completed all steps yet upon creation of the PR. -->

<!-- SECTION A - Adding a new scraper -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#contributing-new-documentations -->

If you’re adding a new scraper, please ensure that you have:

- [ ] Tested the scraper on a local copy of DevDocs
- [ ] Ensured that the docs are styled similarly to other docs on DevDocs
<!-- If the docs don’t have an icon, delete the next four items: -->
- [ ] Added these files to the <code>public/icons/*your_scraper_name*/</code> directory:
  - [ ] `16.png`: a 16×16 pixel icon for the doc
  - [ ] `16@2x.png`: a 32×32 pixel icon for the doc
  - [ ] `SOURCE`: A text file containing the URL to the page the image can be found on or the URL of the original image itself

<!-- SECTION B - Updating an existing documentation to its latest version -->
<!-- See https://github.com/freeCodeCamp/devdocs/blob/main/.github/CONTRIBUTING.md#updating-existing-documentations -->

If you're updating existing documentation to its latest version, please ensure that you have:

- [ ] Updated the versions and releases in the scraper file
- [ ] Ensured the license is up-to-date and that the documentation's entry in the array in `about_tmpl.coffee` matches its data in `self.attribution`
- [ ] Ensured the icons and the `SOURCE` file in <code>public/icons/*your_scraper_name*/</code> are up-to-date if the documentation has a custom icon
- [ ] Ensured `self.links` contains up-to-date urls if `self.links` is defined
- [ ] Tested the changes locally to ensure:
  - The scraper still works without errors
  - The scraped documentation still looks consistent with the rest of DevDocs
  - The categorization of entries is still good
